### PR TITLE
Fix AppStream metadata

### DIFF
--- a/desktop/armagetronad.appdata.xml.in
+++ b/desktop/armagetronad.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>org.armagetronad.@progname@.desktop</id>
+  <id>org.armagetronad.@progname@</id>
   
   <name>@progtitle@</name>
   <summary>3D Lightcycle Game</summary>


### PR DESCRIPTION
Remove the .desktop suffix from app id. It should not be there and causes Flathub linter to fail.